### PR TITLE
Add Gatsby as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "fs-extra": "^10.0.0",
     "lodash": "^4.17.21"
+  },
+  "peerDependencies": {
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
This PR proposes a change that `gatsby@^2.0.0||^3.0.0||^4.0.0` is added as a `peerDependency` to clarify the plugin's runtime environment.